### PR TITLE
Adding .code-workspace exclusion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,69 @@
+# Visual Studio Code Workspace
+*.code-workspace
+
+# IntelliJ IDE
 .idea
+
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# General
 .DS_Store
+.AppleDouble
+.LSOverride
 
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# NodeJS
+node_modules
 .env
-
-node_modules/
-yarn-error.log
-
 build/
 dist/
+
+# Yarn log
+yarn-error.log
 
 ecosystem.config.js
 deploy.key


### PR DESCRIPTION
Close #1 . The .gitignore file has been restructured, comments have been added and the following extensions have been excluded :

- .code-workspace
- Thumbs.db
- Thumbs.db:encryptable
- ehthumbs.db
- ehthumbs_vista.db
- .stackdump
- [Dd]esktop.ini
- $RECYCLE.BIN/
- .cab
- .msi
- .msix
- .msm
- .map
- .lnk
- .AppleDouble
- .LSOverride
- Icon
- ._*
- .DocumentRevisions-V100
- .fseventsd
- .Spotlight-V100
- .TemporaryItems
- .Trashes
- .VolumeIcon.icns
- .com.apple.timemachine.donotpresent
- .AppleDB
- .AppleDesktop
- Network Trash Folder
- Temporary Items
- .apdisk